### PR TITLE
Feat: Update @galachain SDK versions and package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "@gala-chain/dex",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gala-chain/dex",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
-        "@gala-chain/api": "2.3.1",
-        "@gala-chain/chaincode": "2.3.1",
+        "@gala-chain/api": "~2.3.4",
+        "@gala-chain/chaincode": "~2.3.4",
         "@grpc/grpc-js": "1.10.10",
         "dotenv": "^16.0.1",
         "fabric-contract-api": "2.5.6",
         "fabric-shim": "2.5.6"
       },
       "devDependencies": {
-        "@gala-chain/cli": "2.3.1",
-        "@gala-chain/client": "2.3.1",
-        "@gala-chain/test": "2.3.1",
+        "@gala-chain/cli": "~2.3.4",
+        "@gala-chain/client": "~2.3.4",
+        "@gala-chain/test": "~2.3.4",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "@types/jest": "^29.5.12",
         "@types/node": "18.11.9",
@@ -792,9 +792,9 @@
       }
     },
     "node_modules/@gala-chain/api": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@gala-chain/api/-/api-2.3.1.tgz",
-      "integrity": "sha512-SXQ9fHV+tBZvndCtIDsEyOO1A+LI3P6byZLCX26NKUoCfKAFAXZ4dRwVURZV5ifFqCUNlZ+StjhQIAmnSgbueQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@gala-chain/api/-/api-2.3.4.tgz",
+      "integrity": "sha512-McLT8/u8+/E1oatdVwWhLtrZMIgj26B33CojRm9OKXelTCK6fpwR9HudTraacEaWcQ8M/JIpXMQNF7IICX6I0A==",
       "license": "Apache-2.0",
       "dependencies": {
         "bignumber.js": "^9.0.2",
@@ -829,12 +829,12 @@
       "license": "MIT"
     },
     "node_modules/@gala-chain/chaincode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@gala-chain/chaincode/-/chaincode-2.3.1.tgz",
-      "integrity": "sha512-tdtHVC2lAd4YcsPuy6oGebfN3D1osPEmyJZTS9ut+BP/OMtCRYU76Gp70UhxVQJILI5cjnz79xzXMe2p39Sh1w==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@gala-chain/chaincode/-/chaincode-2.3.4.tgz",
+      "integrity": "sha512-XdwkYKTVe58Y22eGAV7/zTSzF24vIm02ZmCrCeofhpAOzYfuHPcJbkFjuCGGR3tqBZTN7r0GlOaLlhMDzTGoXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@gala-chain/api": "2.3.1",
+        "@gala-chain/api": "2.3.4",
         "@grpc/grpc-js": "1.10.10",
         "fabric-contract-api": "2.5.6",
         "fabric-shim": "2.5.6",
@@ -851,13 +851,13 @@
       }
     },
     "node_modules/@gala-chain/cli": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@gala-chain/cli/-/cli-2.3.1.tgz",
-      "integrity": "sha512-H/nt3ice0ZcVswgFWtG9nwWVFYwSdH1CfO1jvlHTf3t2e8NHuZvTEdLSgtm++YeNiUJeFGrFdaKsowZbJHedSw==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@gala-chain/cli/-/cli-2.3.4.tgz",
+      "integrity": "sha512-E+67mMMiNA94RCpA3zDKMGg0kjSVrV9tDQNqgb4RIW3RGG3S4OcX8mzGtvB5Of0nMhjPiRmurNQHYjfY4P8DqQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@gala-chain/api": "2.3.1",
+        "@gala-chain/api": "2.3.4",
         "@noble/secp256k1": "^1.7.1",
         "@oclif/core": "^3",
         "@oclif/plugin-help": "^3",
@@ -872,13 +872,13 @@
       }
     },
     "node_modules/@gala-chain/client": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@gala-chain/client/-/client-2.3.1.tgz",
-      "integrity": "sha512-CfCZbdAjYv5vAN7QFxhgFLmNbQJhI+R0dL7PrVJVpCuFO0nkAhQ7y0tVIZPxZ4PruLYR8+/ZSgByMy6QTVoLwg==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@gala-chain/client/-/client-2.3.4.tgz",
+      "integrity": "sha512-QNivtJK+XAcmgancQssuO1oUaDfbgBJWv5oUtuUOTwkiGkWH5V7qUEuBFWbsd7BfJxyD/bY9BMadcIPdxVmVdg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@gala-chain/api": "2.3.1",
+        "@gala-chain/api": "2.3.4",
         "axios": "^1.6.0",
         "jsonschema": "^1.4.1",
         "tslib": "^2.6.2"
@@ -898,19 +898,19 @@
       }
     },
     "node_modules/@gala-chain/test": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@gala-chain/test/-/test-2.3.1.tgz",
-      "integrity": "sha512-40Tme6Y7sqyx7klduLOzNStAaqEWFVJ09cCdIFmHS0y8WzmDk5JjAQL0SoGFAXDFwApvsAN8Bo+yuC7WeIC+eA==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@gala-chain/test/-/test-2.3.4.tgz",
+      "integrity": "sha512-QidD1I863ncV3+cs+xpaX01Lt/L9LwnEQT7x/Gsnzl2lITwtwfrXr8we8tqirDROI/AKhhNEUzXHtfoeYq3qTQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@gala-chain/client": "2.3.1",
+        "@gala-chain/client": "2.3.4",
         "@jest/globals": "29.7.0",
         "nanoid": "^3.3.6",
         "tslib": "^2.6.2"
       },
       "peerDependencies": {
-        "@gala-chain/api": "2.3.1",
+        "@gala-chain/api": "2.3.4",
         "bignumber.js": "*",
         "class-transformer": "0.5.1",
         "fabric-contract-api": "*",
@@ -8899,9 +8899,9 @@
       }
     },
     "@gala-chain/api": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@gala-chain/api/-/api-2.3.1.tgz",
-      "integrity": "sha512-SXQ9fHV+tBZvndCtIDsEyOO1A+LI3P6byZLCX26NKUoCfKAFAXZ4dRwVURZV5ifFqCUNlZ+StjhQIAmnSgbueQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@gala-chain/api/-/api-2.3.4.tgz",
+      "integrity": "sha512-McLT8/u8+/E1oatdVwWhLtrZMIgj26B33CojRm9OKXelTCK6fpwR9HudTraacEaWcQ8M/JIpXMQNF7IICX6I0A==",
       "requires": {
         "bignumber.js": "^9.0.2",
         "bn.js": "5.2.1",
@@ -8924,11 +8924,11 @@
       }
     },
     "@gala-chain/chaincode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@gala-chain/chaincode/-/chaincode-2.3.1.tgz",
-      "integrity": "sha512-tdtHVC2lAd4YcsPuy6oGebfN3D1osPEmyJZTS9ut+BP/OMtCRYU76Gp70UhxVQJILI5cjnz79xzXMe2p39Sh1w==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@gala-chain/chaincode/-/chaincode-2.3.4.tgz",
+      "integrity": "sha512-XdwkYKTVe58Y22eGAV7/zTSzF24vIm02ZmCrCeofhpAOzYfuHPcJbkFjuCGGR3tqBZTN7r0GlOaLlhMDzTGoXQ==",
       "requires": {
-        "@gala-chain/api": "2.3.1",
+        "@gala-chain/api": "2.3.4",
         "@grpc/grpc-js": "1.10.10",
         "fabric-contract-api": "2.5.6",
         "fabric-shim": "2.5.6",
@@ -8937,12 +8937,12 @@
       }
     },
     "@gala-chain/cli": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@gala-chain/cli/-/cli-2.3.1.tgz",
-      "integrity": "sha512-H/nt3ice0ZcVswgFWtG9nwWVFYwSdH1CfO1jvlHTf3t2e8NHuZvTEdLSgtm++YeNiUJeFGrFdaKsowZbJHedSw==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@gala-chain/cli/-/cli-2.3.4.tgz",
+      "integrity": "sha512-E+67mMMiNA94RCpA3zDKMGg0kjSVrV9tDQNqgb4RIW3RGG3S4OcX8mzGtvB5Of0nMhjPiRmurNQHYjfY4P8DqQ==",
       "dev": true,
       "requires": {
-        "@gala-chain/api": "2.3.1",
+        "@gala-chain/api": "2.3.4",
         "@noble/secp256k1": "^1.7.1",
         "@oclif/core": "^3",
         "@oclif/plugin-help": "^3",
@@ -8954,24 +8954,24 @@
       }
     },
     "@gala-chain/client": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@gala-chain/client/-/client-2.3.1.tgz",
-      "integrity": "sha512-CfCZbdAjYv5vAN7QFxhgFLmNbQJhI+R0dL7PrVJVpCuFO0nkAhQ7y0tVIZPxZ4PruLYR8+/ZSgByMy6QTVoLwg==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@gala-chain/client/-/client-2.3.4.tgz",
+      "integrity": "sha512-QNivtJK+XAcmgancQssuO1oUaDfbgBJWv5oUtuUOTwkiGkWH5V7qUEuBFWbsd7BfJxyD/bY9BMadcIPdxVmVdg==",
       "dev": true,
       "requires": {
-        "@gala-chain/api": "2.3.1",
+        "@gala-chain/api": "2.3.4",
         "axios": "^1.6.0",
         "jsonschema": "^1.4.1",
         "tslib": "^2.6.2"
       }
     },
     "@gala-chain/test": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@gala-chain/test/-/test-2.3.1.tgz",
-      "integrity": "sha512-40Tme6Y7sqyx7klduLOzNStAaqEWFVJ09cCdIFmHS0y8WzmDk5JjAQL0SoGFAXDFwApvsAN8Bo+yuC7WeIC+eA==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@gala-chain/test/-/test-2.3.4.tgz",
+      "integrity": "sha512-QidD1I863ncV3+cs+xpaX01Lt/L9LwnEQT7x/Gsnzl2lITwtwfrXr8we8tqirDROI/AKhhNEUzXHtfoeYq3qTQ==",
       "dev": true,
       "requires": {
-        "@gala-chain/client": "2.3.1",
+        "@gala-chain/client": "2.3.4",
         "@jest/globals": "29.7.0",
         "nanoid": "^3.3.6",
         "tslib": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gala-chain/dex",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "GalaChain DEX Chaincode",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
@@ -23,17 +23,17 @@
     "update-snapshot": "jest --updateSnapshot"
   },
   "dependencies": {
-    "@gala-chain/api": "2.3.1",
-    "@gala-chain/chaincode": "2.3.1",
+    "@gala-chain/api": "~2.3.4",
+    "@gala-chain/chaincode": "~2.3.4",
     "@grpc/grpc-js": "1.10.10",
     "dotenv": "^16.0.1",
     "fabric-contract-api": "2.5.6",
     "fabric-shim": "2.5.6"
   },
   "devDependencies": {
-    "@gala-chain/cli": "2.3.1",
-    "@gala-chain/client": "2.3.1",
-    "@gala-chain/test": "2.3.1",
+    "@gala-chain/cli": "~2.3.4",
+    "@gala-chain/client": "~2.3.4",
+    "@gala-chain/test": "~2.3.4",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/jest": "^29.5.12",
     "@types/node": "18.11.9",


### PR DESCRIPTION
This commit updates the versions of the @galachain SDK libraries:
- @galachain/api
- @galachain/chaincode
- @galachain/cli
- @galachain/client
- @galachain/test

All have been set to ~2.3.4.

The main package version has also been bumped from 1.0.3 to 1.0.4. The package-lock.json file has been updated accordingly by running npm install.