### PR TITLE
v1.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gala-chain/dex",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gala-chain/dex",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "dependencies": {
         "@gala-chain/api": "~2.3.4",
         "@gala-chain/chaincode": "~2.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gala-chain/dex",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "GalaChain DEX Chaincode",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",


### PR DESCRIPTION
bump version to 1.0.7

executed manually due to failure in github action / bump version job. Re-run failed due to recent merge to main.