### PR TITLE
Expose quote exact amount

### DIFF
--- a/e2e/dex.spec.ts
+++ b/e2e/dex.spec.ts
@@ -315,6 +315,34 @@ describe("DexV3Contract:LimitOrder", () => {
     // Then
     expect(response).toEqual(transactionSuccess());
   });
+
+  test("QuoteExactAmount", async () => {
+    // Given
+    const pool = new Pool(
+      "GALA|Unit|none|none",
+      "TOWN|Unit|none|none",
+      token0ClassKey,
+      token1ClassKey,
+      DexFeePercentageTypes.FEE_0_3_PERCENT,
+      new BigNumber("1"),
+      0
+    );
+
+    const dto = new QuoteExactAmountDto(
+      token0ClassKey,
+      token1ClassKey,
+      DexFeePercentageTypes.FEE_0_3_PERCENT,
+      new BigNumber("1000000000"),
+      true,
+      pool
+    );
+
+    // When
+    const response = await client.dex.QuoteExactAmount(dto);
+
+    // Then
+    expect(response).toEqual(transactionSuccess());
+  });
 });
 
 interface DexV3ContractAPI {

--- a/src/api/types/DexDtos.spec.ts
+++ b/src/api/types/DexDtos.spec.ts
@@ -25,7 +25,6 @@ import {
   CollectDto,
   CollectProtocolFeesDto,
   CreatePoolDto,
-  DexFeePercentageTypes,
   GetAddLiquidityEstimationDto,
   GetPoolDto,
   GetPositionDto,
@@ -40,6 +39,7 @@ import {
   SwapDto
 } from "./DexDtos";
 import { TickData } from "./TickData";
+import { DexFeePercentageTypes } from "./DexFeeTypes";
 
 describe("DexDtos", () => {
   const mockToken0 = plainToInstance(TokenClassKey, {

--- a/src/api/types/DexDtos.ts
+++ b/src/api/types/DexDtos.ts
@@ -43,10 +43,10 @@ import { JSONSchema } from "class-validator-jsonschema";
 
 import { PositionInPool, f18 } from "../utils";
 import { BigNumberIsNegative, BigNumberIsNotNegative, BigNumberIsPositive, IsLessThan } from "../validators";
-import { IDexLimitOrderModel } from "./DexLimitOrderModel";
-import { TickData } from "./TickData";
-import { Pool } from "./DexV3Pool";
 import { DexFeePercentageTypes } from "./DexFeeTypes";
+import { IDexLimitOrderModel } from "./DexLimitOrderModel";
+import { Pool } from "./DexV3Pool";
+import { TickData } from "./TickData";
 
 export class CreatePoolDto extends SubmitCallDTO {
   @IsNotEmpty()

--- a/src/api/types/DexDtos.ts
+++ b/src/api/types/DexDtos.ts
@@ -45,12 +45,8 @@ import { PositionInPool, f18 } from "../utils";
 import { BigNumberIsNegative, BigNumberIsNotNegative, BigNumberIsPositive, IsLessThan } from "../validators";
 import { IDexLimitOrderModel } from "./DexLimitOrderModel";
 import { TickData } from "./TickData";
-
-export enum DexFeePercentageTypes {
-  FEE_0_05_PERCENT = 500, // 0.05%
-  FEE_0_3_PERCENT = 3000, // 0.3%
-  FEE_1_PERCENT = 10000 // 1%
-}
+import { Pool } from "./DexV3Pool";
+import { DexFeePercentageTypes } from "./DexFeeTypes";
 
 export class CreatePoolDto extends SubmitCallDTO {
   @IsNotEmpty()
@@ -152,12 +148,18 @@ export class QuoteExactAmountDto extends ChainCallDTO {
   @BigNumberProperty()
   public amount: BigNumber;
 
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => Pool)
+  public pool?: Pool;
+
   constructor(
     token0: TokenClassKey,
     token1: TokenClassKey,
     fee: DexFeePercentageTypes,
     amount: BigNumber,
-    zeroForOne: boolean
+    zeroForOne: boolean,
+    pool?: Pool
   ) {
     super();
     this.token0 = token0;
@@ -165,6 +167,9 @@ export class QuoteExactAmountDto extends ChainCallDTO {
     this.fee = fee;
     this.amount = amount;
     this.zeroForOne = zeroForOne;
+    if (pool !== undefined) {
+      this.pool = pool;
+    }
   }
 }
 

--- a/src/api/types/DexFeeTypes.ts
+++ b/src/api/types/DexFeeTypes.ts
@@ -13,16 +13,8 @@
  * limitations under the License.
  */
 
-export * from "./DexDtos";
-export * from "./DexFeeConfig";
-export * from "./DexFeeTypes";
-export * from "./DexGlobalLimitOrderConfig";
-export * from "./DexLimitOrder";
-export * from "./DexLimitOrderCommitment";
-export * from "./DexLimitOrderModel";
-export * from "./DexPositionData";
-export * from "./DexPositionOwner";
-export * from "./DexV3Pool";
-export * from "./TickData";
-export * from "./BatchSubmitAuthorities";
-export * from "./BatchSubmitDtos";
+export enum DexFeePercentageTypes {
+  FEE_0_05_PERCENT = 500, // 0.05%
+  FEE_0_3_PERCENT = 3000, // 0.3%
+  FEE_1_PERCENT = 10000 // 1%
+}

--- a/src/api/types/DexPositionData.spec.ts
+++ b/src/api/types/DexPositionData.spec.ts
@@ -16,7 +16,7 @@ import { TokenClassKey } from "@gala-chain/api";
 import BigNumber from "bignumber.js";
 import { plainToInstance } from "class-transformer";
 
-import { DexFeePercentageTypes } from "./DexDtos";
+import { DexFeePercentageTypes } from "./DexFeeTypes";
 import { DexPositionData } from "./DexPositionData";
 
 const tokenClass0Properties = {

--- a/src/api/types/DexPositionData.ts
+++ b/src/api/types/DexPositionData.ts
@@ -21,7 +21,7 @@ import { JSONSchema } from "class-validator-jsonschema";
 
 import { requirePosititve } from "../utils";
 import { IsLessThan } from "../validators";
-import { DexFeePercentageTypes } from "./DexDtos";
+import { DexFeePercentageTypes } from "./DexFeeTypes";
 import { TickData } from "./TickData";
 
 @JSONSchema({

--- a/src/api/types/DexV3Pool.spec.ts
+++ b/src/api/types/DexV3Pool.spec.ts
@@ -17,7 +17,7 @@ import { BigNumber } from "bignumber.js";
 import { plainToInstance } from "class-transformer";
 
 import { SwapState, tickToSqrtPrice } from "../utils";
-import { DexFeePercentageTypes } from "./DexDtos";
+import { DexFeePercentageTypes } from "./DexFeeTypes";
 import { DexPositionData } from "./DexPositionData";
 import { Pool } from "./DexV3Pool";
 import { TickData } from "./TickData";

--- a/src/api/types/DexV3Pool.ts
+++ b/src/api/types/DexV3Pool.ts
@@ -44,7 +44,7 @@ import {
   tickToSqrtPrice
 } from "../utils";
 import { BigNumberIsNotNegative, IsStringRecord } from "../validators";
-import { DexFeePercentageTypes } from "./DexDtos";
+import { DexFeePercentageTypes } from "./DexFeeTypes";
 import { DexPositionData } from "./DexPositionData";
 import { TickData } from "./TickData";
 

--- a/src/chaincode/dex/index.ts
+++ b/src/chaincode/dex/index.ts
@@ -38,3 +38,4 @@ export * from "./dexUtils";
 export * from "./configurePoolDexFee";
 export * from "./batchSubmitAuthorizations";
 export * from "./updateBitmap";
+export * from "./swap.helper";

--- a/src/chaincode/dex/quoteFuncs.ts
+++ b/src/chaincode/dex/quoteFuncs.ts
@@ -47,11 +47,16 @@ export async function quoteExactAmount(
   const [token0, token1] = validateTokenOrder(dto.token0, dto.token1);
 
   const zeroForOne = dto.zeroForOne;
-
-  // Generate pool key from tokens and fee tier
-  const key = ctx.stub.createCompositeKey(Pool.INDEX_KEY, [token0, token1, dto.fee.toString()]);
-  const pool = await getObjectByKey(ctx, Pool, key);
-  if (pool == undefined) throw new NotFoundError("Pool does not exist");
+  let pool: Pool;
+  
+  if (dto.pool !== undefined) {
+    pool = dto.pool;
+  } else {
+    // Generate pool key from tokens and fee tier
+    const key = ctx.stub.createCompositeKey(Pool.INDEX_KEY, [token0, token1, dto.fee.toString()]);
+    pool = await getObjectByKey(ctx, Pool, key);
+    if (pool == undefined) throw new NotFoundError("Pool does not exist");
+  }
 
   // Define square root price limit as the maximum possible value in trade direction for estimation purposes
   const sqrtPriceLimit = zeroForOne

--- a/src/chaincode/dex/quoteFuncs.ts
+++ b/src/chaincode/dex/quoteFuncs.ts
@@ -48,7 +48,7 @@ export async function quoteExactAmount(
 
   const zeroForOne = dto.zeroForOne;
   let pool: Pool;
-  
+
   if (dto.pool !== undefined) {
     pool = dto.pool;
   } else {


### PR DESCRIPTION
Updating QuoteExactAmount to allow a pool to be submitted in the DTO, which eliminates the need to do the query inside the function. This will allow off-chain users to take advantage of the logic if they have retrieved pool information ahead of time.