### PR TITLE
Add optional sortBy to GetUserPositions and support TOKEN_PAIR sorting

### DIFF
--- a/src/api/types/DexDtos.spec.ts
+++ b/src/api/types/DexDtos.spec.ts
@@ -676,6 +676,18 @@ describe("DexDtos", () => {
       expect(dto.bookmark).toBe("bookmark-123");
     });
 
+    it("should allow sortBy in GetUserPositionsDto", async () => {
+      // Given
+      const dto = new GetUserPositionsDto(mockUserRef, "bookmark-123", 5, "TOKEN_PAIR");
+
+      // When
+      const validationErrors = await dto.validate();
+
+      // Then
+      expect(validationErrors.length).toBe(0);
+      expect(dto.sortBy).toBe("TOKEN_PAIR");
+    });
+
     it("should fail validation with limit out of range", async () => {
       // Given
       const dto = new GetUserPositionsDto(mockUserRef, undefined, 15); // Max is 10

--- a/src/api/types/DexDtos.ts
+++ b/src/api/types/DexDtos.ts
@@ -450,11 +450,16 @@ export class GetUserPositionsDto extends ChainCallDTO {
   @IsString()
   public bookmark?: string;
 
-  constructor(user: UserRef, bookmark?: string, limit = 10) {
+  @IsOptional()
+  @IsString()
+  public sortBy?: string;
+
+  constructor(user: UserRef, bookmark?: string, limit = 10, sortBy?: string) {
     super();
     this.user = user;
     this.bookmark = bookmark;
     this.limit = limit;
+    this.sortBy = sortBy;
   }
 }
 

--- a/src/chaincode/dex/getUserPositions.spec.ts
+++ b/src/chaincode/dex/getUserPositions.spec.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { TokenClass, TokenClassKey } from "@gala-chain/api";
+import { TokenClass, TokenClassKey, asValidUserAlias } from "@gala-chain/api";
 import { currency, fixture, transactionErrorMessageContains, users } from "@gala-chain/test";
 import BigNumber from "bignumber.js";
 import { plainToInstance } from "class-transformer";
@@ -136,6 +136,217 @@ describe("GetPosition", () => {
     expect(response.Data?.positions[0].poolHash).toStrictEqual(positionData.poolHash);
     expect(response.Data?.positions[1].positionId).toStrictEqual(secondPositionData.positionId);
     expect(response.Data?.positions[1].poolHash).toStrictEqual(secondPositionData.poolHash);
+  });
+
+  test("should sort positions by token pair when sortBy is TOKEN_PAIR", async () => {
+    // Given
+    const fee = DexFeePercentageTypes.FEE_1_PERCENT;
+    const initialSqrtPrice = new BigNumber("1");
+    const authority = asValidUserAlias(users.admin.identityKey);
+
+    const tokenAProps = {
+      collection: "AAA",
+      category: "Unit",
+      type: "none",
+      additionalKey: "none"
+    };
+    const tokenBProps = {
+      collection: "BBB",
+      category: "Unit",
+      type: "none",
+      additionalKey: "none"
+    };
+    const tokenCProps = {
+      collection: "CCC",
+      category: "Unit",
+      type: "none",
+      additionalKey: "none"
+    };
+
+    const tokenAKey = plainToInstance(TokenClassKey, tokenAProps);
+    const tokenBKey = plainToInstance(TokenClassKey, tokenBProps);
+    const tokenCKey = plainToInstance(TokenClassKey, tokenCProps);
+
+    const tokenAClass = plainToInstance(TokenClass, {
+      ...tokenAProps,
+      network: "GC",
+      decimals: 8,
+      maxSupply: new BigNumber("100000"),
+      isNonFungible: false,
+      maxCapacity: new BigNumber("100000"),
+      authorities: [authority],
+      name: "Token A",
+      symbol: "AAA",
+      description: "Test token A",
+      image: "https://app.gala.games/favicon.ico",
+      totalBurned: new BigNumber("0"),
+      totalMintAllowance: new BigNumber("0"),
+      totalSupply: new BigNumber("0")
+    });
+    const tokenBClass = plainToInstance(TokenClass, {
+      ...tokenBProps,
+      network: "GC",
+      decimals: 8,
+      maxSupply: new BigNumber("100000"),
+      isNonFungible: false,
+      maxCapacity: new BigNumber("100000"),
+      authorities: [authority],
+      name: "Token B",
+      symbol: "BBB",
+      description: "Test token B",
+      image: "https://app.gala.games/favicon.ico",
+      totalBurned: new BigNumber("0"),
+      totalMintAllowance: new BigNumber("0"),
+      totalSupply: new BigNumber("0")
+    });
+    const tokenCClass = plainToInstance(TokenClass, {
+      ...tokenCProps,
+      network: "GC",
+      decimals: 8,
+      maxSupply: new BigNumber("100000"),
+      isNonFungible: false,
+      maxCapacity: new BigNumber("100000"),
+      authorities: [authority],
+      name: "Token C",
+      symbol: "CCC",
+      description: "Test token C",
+      image: "https://app.gala.games/favicon.ico",
+      totalBurned: new BigNumber("0"),
+      totalMintAllowance: new BigNumber("0"),
+      totalSupply: new BigNumber("0")
+    });
+
+    const poolAB = new Pool(
+      tokenAKey.toStringKey(),
+      tokenBKey.toStringKey(),
+      tokenAKey,
+      tokenBKey,
+      fee,
+      initialSqrtPrice
+    );
+    const poolAC = new Pool(
+      tokenAKey.toStringKey(),
+      tokenCKey.toStringKey(),
+      tokenAKey,
+      tokenCKey,
+      fee,
+      initialSqrtPrice
+    );
+    const poolCA = new Pool(
+      tokenCKey.toStringKey(),
+      tokenAKey.toStringKey(),
+      tokenCKey,
+      tokenAKey,
+      fee,
+      initialSqrtPrice
+    );
+
+    const positionAB1 = new DexPositionData(
+      poolAB.genPoolHash(),
+      "pos-ab-1",
+      100,
+      0,
+      tokenAKey,
+      tokenBKey,
+      fee
+    );
+    const positionAB2 = new DexPositionData(
+      poolAB.genPoolHash(),
+      "pos-ab-2",
+      100,
+      0,
+      tokenAKey,
+      tokenBKey,
+      fee
+    );
+    const positionAC = new DexPositionData(
+      poolAC.genPoolHash(),
+      "pos-ac",
+      100,
+      0,
+      tokenAKey,
+      tokenCKey,
+      fee
+    );
+    const positionCA = new DexPositionData(
+      poolCA.genPoolHash(),
+      "pos-ca",
+      100,
+      0,
+      tokenCKey,
+      tokenAKey,
+      fee
+    );
+
+    const ownerAB = new DexPositionOwner(users.testUser1.identityKey, poolAB.genPoolHash());
+    ownerAB.addPosition("0:100", positionAB1.positionId);
+    ownerAB.addPosition("0:100", positionAB2.positionId);
+
+    const ownerAC = new DexPositionOwner(users.testUser1.identityKey, poolAC.genPoolHash());
+    ownerAC.addPosition("0:100", positionAC.positionId);
+
+    const ownerCA = new DexPositionOwner(users.testUser1.identityKey, poolCA.genPoolHash());
+    ownerCA.addPosition("0:100", positionCA.positionId);
+
+    const makeTicks = (poolHash: string) => {
+      const lowerTick = plainToInstance(TickData, {
+        poolHash,
+        tick: 0,
+        liquidityGross: new BigNumber("100"),
+        initialised: true,
+        liquidityNet: new BigNumber("100"),
+        feeGrowthOutside0: new BigNumber("0"),
+        feeGrowthOutside1: new BigNumber("0")
+      });
+      const upperTick = plainToInstance(TickData, {
+        ...lowerTick,
+        tick: 100
+      });
+      return [lowerTick, upperTick];
+    };
+
+    const ticks = [
+      ...makeTicks(poolAB.genPoolHash()),
+      ...makeTicks(poolAC.genPoolHash()),
+      ...makeTicks(poolCA.genPoolHash())
+    ];
+
+    const { ctx, contract } = fixture(DexV3Contract)
+      .registeredUsers(users.testUser1)
+      .savedState(
+        poolAB,
+        poolAC,
+        poolCA,
+        ownerAB,
+        ownerAC,
+        ownerCA,
+        positionAB1,
+        positionAB2,
+        positionAC,
+        positionCA,
+        tokenAClass,
+        tokenBClass,
+        tokenCClass,
+        ...ticks
+      );
+
+    const getUserPositionsDto = new GetUserPositionsDto(
+      users.testUser1.identityKey,
+      undefined,
+      10,
+      "TOKEN_PAIR"
+    );
+
+    // When
+    const response = await contract.GetUserPositions(ctx, getUserPositionsDto);
+
+    // Then
+    expect(response.Data?.positions.map((p) => p.positionId)).toEqual([
+      "pos-ab-1",
+      "pos-ab-2",
+      "pos-ac",
+      "pos-ca"
+    ]);
   });
 
   test("should fetch next set of positions based on bookmark", async () => {

--- a/src/chaincode/dex/getUserPositions.ts
+++ b/src/chaincode/dex/getUserPositions.ts
@@ -130,7 +130,24 @@ export async function getUserPositions(
   // Add token metadata to response
   const userPositionWithMetadata = await addMetaDataToUserPositions(ctx, userPositions);
 
-  return new GetUserPositionsResDto(userPositionWithMetadata, newBookmark);
+  let sortedPositions = userPositionWithMetadata;
+  if (dto.sortBy === "TOKEN_PAIR") {
+    sortedPositions = userPositionWithMetadata
+      .map((position, index) => ({ position, index }))
+      .sort((a, b) => {
+        const aToken0 = (a.position.token0Symbol || "").toLowerCase();
+        const aToken1 = (a.position.token1Symbol || "").toLowerCase();
+        const bToken0 = (b.position.token0Symbol || "").toLowerCase();
+        const bToken1 = (b.position.token1Symbol || "").toLowerCase();
+
+        if (aToken0 !== bToken0) return aToken0.localeCompare(bToken0);
+        if (aToken1 !== bToken1) return aToken1.localeCompare(bToken1);
+        return a.index - b.index; // Preserve original (chronological) order
+      })
+      .map((item) => item.position);
+  }
+
+  return new GetUserPositionsResDto(sortedPositions, newBookmark);
 }
 
 /**


### PR DESCRIPTION
This change adds an optional `sortBy` parameter to `GetUserPositionsDto` and introduces support for sorting user positions by token pair when `sortBy` is set to `TOKEN_PAIR`. The chaincode handler now conditionally sorts the enriched positions using `token0Symbol` and `token1Symbol` (case-insensitive) and preserves the original chronological order for ties by using the original index as a stable fallback. New unit tests were added to validate DTO acceptance of `sortBy` and to verify the correct ordering of positions returned when token-pair sorting is requested.